### PR TITLE
Removes siteId from Constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ use CxInsightSDK\Traffic;
 
 $traffic = new Traffic(
     'test@example.com',
-    'apikey',
-    [
-        'siteId'
-    ]
+    'apikey'
 );
 
 // Get data for one week's time
@@ -48,6 +45,9 @@ $options = [
             'group' => 'url',
             'items'  => ['http://example.com']
         ]
+    ],
+    'siteIds' => [
+        'siteId'
     ]
 ];
 

--- a/src/BaseSDK.php
+++ b/src/BaseSDK.php
@@ -25,13 +25,6 @@ abstract class BaseSDK
     protected $apiKey;
 
     /**
-     * Cxense IDs of sites to fetch data for
-     *
-     * @var array
-     */
-    protected $siteIds;
-
-    /**
      * API endpoint to request data from
      *
      * @var string
@@ -45,11 +38,10 @@ abstract class BaseSDK
      */
     protected $client;
 
-    public function __construct($username, $apiKey, array $siteIds)
+    public function __construct($username, $apiKey)
     {
         $this->username = $username;
         $this->apiKey = $apiKey;
-        $this->siteIds = $siteIds;
     }
 
     /**

--- a/tests/BaseSDKTest.php
+++ b/tests/BaseSDKTest.php
@@ -37,10 +37,7 @@ class BaseSDKTest extends \PHPUnit_Framework_TestCase
             'CxInsightSDK\Tests\Classes\TestSDK',
             [
                 'username',
-                'apikey',
-                [
-                    'siteId'
-                ]
+                'apikey'
             ]
         )
             ->makePartial()
@@ -67,10 +64,7 @@ class BaseSDKTest extends \PHPUnit_Framework_TestCase
     {
         $testSDK = new TestSDK(
             'username',
-            'apikey',
-            [
-                'siteId'
-            ]
+            'apikey'
         );
 
         $client = $testSDK->getClient();


### PR DESCRIPTION
SiteId is now just treated as a normal option in the request as not all
requests need the site id.