### PR TITLE
Adds Support for Debug Query Parameter

### DIFF
--- a/src/Document/Search.php
+++ b/src/Document/Search.php
@@ -10,4 +10,30 @@ class Search extends BaseSDK
      * @{inheritDoc}
      */
     protected $requestPath = '/document/search';
+
+    /**
+     * Handles runnning a search request. Currently moves debug from options
+     * to query parameters
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    protected function runRequest($options = [])
+    {
+        $queryParameters = [];
+
+        if ($options['debug']) {
+            $queryParameters['debug'] = $options['debug'];
+            // cXense freaks out if you pass debug in as an option so unset it
+            unset($options['debug']);
+        }
+
+        $originalPath = $this->requestPath;
+        $this->requestPath = $this->requestPath . '?' . http_build_query($queryParameters);
+        $result = parent::runRequest($options);
+        $this->requestPath = $originalPath;
+
+        return $result;
+    }
 }


### PR DESCRIPTION
At our request, cXense added a debug flag so we could see score
explanations. However, the new flag they added has to come in the
query parameters and not in the options. This change looks for the
debug option and moves it to query parameters.